### PR TITLE
Ability to build on Mac OS X Darwin.

### DIFF
--- a/config.darwin
+++ b/config.darwin
@@ -1,0 +1,31 @@
+# Installation directories
+# System's libraries directory (where binary libraries are installed)
+LUA_LIBDIR=./LuaJIT/lib/
+# Lua includes directory
+LUA_INC= ./LuaJIT/src/ 
+RTMIDI_INC= /opt/homebrew/Cellar/rtmidi/6.0.0/include/rtmidi
+RTMIDI_LIB= /opt/homebrew/Cellar/rtmidi/6.0.0/lib/
+
+
+
+# OS dependent
+# for Linux
+#LIB_OPTION= -shared
+#DEFS= -D__LINUX_ALSASEQ__
+#LIBRARY= -lpthread -lasound
+
+# for MacOS X
+LIB_OPTION= -undefined dynamic_lookup  -dynamiclib  -undefined dynamic_lookup -fPIC  -lrtmidi 
+DEFS= -D__MACOSX_CORE__ -std=c++11 -mmacosx-version-min=11.0 
+LIBRARY= -framework CoreMIDI -framework CoreFoundation -framework CoreAudio -L$(RTMIDI_LIB) 
+
+LIBNAME= $T.dylib
+
+# Compilation directives
+WARN= -O2 -Wall -fPIC -W -Waggregate-return -Wcast-align -Wmissing-prototypes -Wnested-externs -Wshadow -Wwrite-strings -Wpointer-arith -pedantic
+INCS= -I$(LUA_INC) -I$(RTMIDI_INC)
+CFLAGS= $(WARN) $(INCS)
+OCFLAGS= -O2 -Wall $(INCS)
+CC=clang
+
+

--- a/config.darwin
+++ b/config.darwin
@@ -3,21 +3,13 @@
 LUA_LIBDIR=./LuaJIT/lib/
 # Lua includes directory
 LUA_INC= ./LuaJIT/src/ 
-RTMIDI_INC= /opt/homebrew/Cellar/rtmidi/6.0.0/include/rtmidi
-RTMIDI_LIB= /opt/homebrew/Cellar/rtmidi/6.0.0/lib/
-
-
+RTMIDI_INC=./rtmidi/
 
 # OS dependent
-# for Linux
-#LIB_OPTION= -shared
-#DEFS= -D__LINUX_ALSASEQ__
-#LIBRARY= -lpthread -lasound
-
 # for MacOS X
-LIB_OPTION= -undefined dynamic_lookup  -dynamiclib  -undefined dynamic_lookup -fPIC  -lrtmidi 
+LIB_OPTION= -undefined dynamic_lookup  -dynamiclib  -undefined dynamic_lookup -fPIC 
 DEFS= -D__MACOSX_CORE__ -std=c++11 -mmacosx-version-min=11.0 
-LIBRARY= -framework CoreMIDI -framework CoreFoundation -framework CoreAudio -L$(RTMIDI_LIB) 
+LIBRARY= -framework CoreMIDI -framework CoreFoundation -framework CoreAudio
 
 LIBNAME= $T.dylib
 

--- a/config.darwin
+++ b/config.darwin
@@ -28,4 +28,5 @@ CFLAGS= $(WARN) $(INCS)
 OCFLAGS= -O2 -Wall $(INCS)
 CC=clang
 
+export MACOSX_DEPLOYMENT_TARGET="10.3";
 

--- a/makefile
+++ b/makefile
@@ -1,11 +1,26 @@
 T= luamidi
-V= 0.1
-CONFIG= ./config
+V= 0.1a
+
+ifeq '$(findstring ;,$(PATH))' ';'
+    detected_OS := Windows
+else
+    detected_OS := $(shell uname 2>/dev/null || echo Unknown)
+    detected_OS := $(patsubst CYGWIN%,Cygwin,$(detected_OS))
+    detected_OS := $(patsubst MSYS%,MSYS,$(detected_OS))
+    detected_OS := $(patsubst MINGW%,MSYS,$(detected_OS))
+endif
+
+# default to the existing config.
+CONFIG=./config
+
+ifeq ($(detected_OS),Darwin)        # Mac OS X
+    CONFIG=./config.darwin
+endif
 
 include $(CONFIG)
 
 SRC= $(T).cpp
-OBJS= $(T).o RtMidi.o
+OBJS= $(T).o 
 
 # lib: src/$(LIBNAME)
 

--- a/makefile
+++ b/makefile
@@ -20,12 +20,15 @@ endif
 include $(CONFIG)
 
 SRC= $(T).cpp
-OBJS= $(T).o 
+OBJS= $(T).o RtMidi.o
 
-# lib: src/$(LIBNAME)
+all: $(OBJS) src/$(LIBNAME) 
 
 %.o : src/%.cpp
 	$(CC) $(OCFLAGS) $(DEFS) -c $(<) -o $@
+
+RtMidi.o:
+	$(CC) $(OCFLAGS) $(DEFS) $(LIB_OPTION) rtMidi/rtMidi.cpp -o RtMidi.o
 
 src/$(LIBNAME) : $(OBJS)
 	$(CC) $(CFLAGS) $(DEFS) $(LIB_OPTION) -o src/$(LIBNAME) $(OBJS) $(LIBRARY)

--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ OBJS= $(T).o
 	$(CC) $(OCFLAGS) $(DEFS) -c $(<) -o $@
 
 src/$(LIBNAME) : $(OBJS)
-	export MACOSX_DEPLOYMENT_TARGET="10.3"; $(CC) $(CFLAGS) $(DEFS) $(LIB_OPTION) -o src/$(LIBNAME) $(OBJS) $(LIBRARY)
+	$(CC) $(CFLAGS) $(DEFS) $(LIB_OPTION) -o src/$(LIBNAME) $(OBJS) $(LIBRARY)
 
 install: src/$(LIBNAME)
 	mkdir -p $(LUA_LIBDIR)

--- a/tests/love2d/main.lua
+++ b/tests/love2d/main.lua
@@ -45,6 +45,9 @@
 -- CC comamands
 -- http://www.indiana.edu/~emusic/cntrlnumb.html
 
+package.cpath = package.cpath .. ";src/?.dylib"
+
+
 local midi = require "luamidi"
 
 local inputports = midi.getinportcount()


### PR DESCRIPTION
Looking for feedback on this MR.

Things I have already thought of / would like feedback on before continuing.

1. Dont bump the version in the makefile (I didnt want to trash the existing window dlls in my test builds).
2. Modify my build to build multi-arch ARM64 / Intel (at this time it builds just the native version, and you can't use arm64 on intel, and you cant use intel version on an arm64 love)
I do not know how to do this.
3.  Not requiring my modification for package.cpath for the tests. I dont know how to work around this though.

I unfortunately do not have a windows system to test if I have broken the build for them.   This build system was 14.2.1 although the build target is a much earlier release of darwin/mac os, I see no reason why older releases should not be able to build this.

Example build output:

```
✗ make
clang -O2 -Wall -I./LuaJIT/src/  -I./rtmidi/ -D__MACOSX_CORE__ -std=c++11 -mmacosx-version-min=11.0  -c src/luamidi.cpp -o luamidi.o
src/luamidi.cpp:35:13: warning: unused function 'debugLua' [-Wunused-function]
static void debugLua(lua_State *L)
            ^
src/luamidi.cpp:93:19: warning: unused function 'toMidiOut' [-Wunused-function]
static RtMidiOut* toMidiOut(lua_State *L, int index)
                  ^
src/luamidi.cpp:176:18: warning: unused function 'toMidiIn' [-Wunused-function]
static RtMidiIn* toMidiIn(lua_State *L, int index)
                 ^
src/luamidi.cpp:184:18: warning: unused function 'checkMidiIn' [-Wunused-function]
static RtMidiIn* checkMidiIn(lua_State* L, int index)
                 ^
4 warnings generated.
clang -O2 -Wall -I./LuaJIT/src/  -I./rtmidi/ -D__MACOSX_CORE__ -std=c++11 -mmacosx-version-min=11.0  -undefined dynamic_lookup  -dynamiclib  -undefined dynamic_lookup -fPIC  rtMidi/rtMidi.cpp -o RtMidi.o
clang -O2 -Wall -fPIC -W -Waggregate-return -Wcast-align -Wmissing-prototypes -Wnested-externs -Wshadow -Wwrite-strings -Wpointer-arith -pedantic -I./LuaJIT/src/  -I./rtmidi/ -D__MACOSX_CORE__ -std=c++11 -mmacosx-version-min=11.0  -undefined dynamic_lookup  -dynamiclib  -undefined dynamic_lookup -fPIC  -o src/luamidi.dylib luamidi.o RtMidi.o -framework CoreMIDI -framework CoreFoundation -framework CoreAudio
```

And artifacts:

```
➜  lovemidi git:(master) ✗ ls *.o
RtMidi.o  luamidi.o
➜  lovemidi git:(master) ✗ ls src/*dylib
src/luamidi.dylib
➜  lovemidi git:(master) ✗ file src/*dylib
src/luamidi.dylib: Mach-O 64-bit dynamically linked shared library arm64
```
